### PR TITLE
Kcho/mediaflux test

### DIFF
--- a/lochness/__init__.py
+++ b/lochness/__init__.py
@@ -43,6 +43,48 @@ Subject = col.namedtuple('Subject', [
 ])
 
 
+class Subject(object):
+    def __init__(self, active, phoenix_study, phoenix_id, consent, beiwe,
+                 icognition, saliva, xnat, redcap, dropbox,
+                 box, mediaflux, mindlamp, daris, rpms,
+                 general, protected, metadata_file):
+        self.active = active
+        self.study = phoenix_study
+        self.id = phoenix_id
+        self.consent = consent
+        self.beiwe = beiwe
+        self.icognition = icognition
+        self.saliva = saliva
+        self.xnat = xnat
+        self.redcap = redcap
+        self.dropbox = dropbox
+        self.box = box
+        self.mediaflux = mediaflux
+        self.mindlamp = mindlamp
+        self.daris = daris
+        self.rpms = rpms
+        self.general_folder = general
+        self.protected_folder = protected
+        self.metadata_csv = metadata_file
+
+    def asdict(self):
+        '''emulating collection._asdict()'''
+        return {'active': self.active, 'study': self.study,
+                'id': self.id, 'consent': self.consent,
+                'beiwe': self.beiwe, 'icognition': self.icognition,
+                'saliva': self.saliva, 'xnat': self.xnat,
+                'redcap': self.redcap, 'dropbox': self.dropbox,
+                'box': self.box, 'mediaflux': self.mediaflux,
+                'mindlamp': self.mindlamp, 'daris': self.daris,
+                'rpms': self.rpms, 'general_folder': self.general_folder,
+                'protected_folder': self.protected_folder,
+                'metadata_csv': self.metadata_csv}
+        
+    def to_bids(self):
+        self.general_folder = os.path.join(self.general_folder, self.study)
+        self.protected_folder = os.path.join(self.protected_folder, self.study)
+
+
 def initialize_metadata(Lochness, args) -> None:
     '''Create (overwrite) metadata.csv using either REDCap or RPMS database'''
     for study_name in args.studies:
@@ -182,7 +224,11 @@ def _subjects(Lochness, study, general_folder, protected_folder, metadata_file):
                           icognition, saliva, xnat, redcap, dropbox,
                           box, mediaflux, mindlamp, daris, rpms,
                           general, protected, metadata_file)
-        logger.debug('subject metadata blob:\n{0}'.format(json.dumps(subject._asdict(), indent=2)))
+
+        if Lochness['BIDS']:
+            subject.to_bids()
+
+        logger.debug('subject metadata blob:\n{0}'.format(json.dumps(subject.asdict(), indent=2)))
         yield subject
 
 

--- a/lochness/beiwe/__init__.py
+++ b/lochness/beiwe/__init__.py
@@ -41,8 +41,14 @@ def sync(Lochness, subject, dry=False):
             study_frag,beiwe_id = uid
             study_name,study_id = mano.expand_study_id(Keyring, study_frag)
             study_name_enc = study_name.encode('utf-8')
-            dst_general_folder = tree.get('phone', subject.general_folder, beiwe_id=beiwe_id)
-            dst_protected_folder = tree.get('phone', subject.protected_folder, beiwe_id=beiwe_id)
+            dst_general_folder = tree.get('phone',
+                                          subject.general_folder,
+                                          beiwe_id=beiwe_id,
+                                          BIDS=Lochness['BIDS'])
+            dst_protected_folder = tree.get('phone',
+                                            subject.protected_folder,
+                                            beiwe_id=beiwe_id,
+                                            BIDS=Lochness['BIDS'])
             # save a hidden file with the study id, original name, and sanitized name
             save_study_file(dst_general_folder, study_id, study_name)
             protected_streams = set(PROTECT)

--- a/lochness/box/__init__.py
+++ b/lochness/box/__init__.py
@@ -341,11 +341,13 @@ def sync_module(Lochness: 'lochness.config',
                     key = enc_key if encrypt else None
 
                     processed = product.get('processed', False)
+
                     # For DPACC, get processed from the config.yml
                     output_base = tree.get(
                             datatype,
                             output_base,
-                            processed=processed)
+                            processed=processed,
+                            BIDS=Lochness['BIDS'])
 
                     compress = product.get('compress', False)
 

--- a/lochness/daris/__init__.py
+++ b/lochness/daris/__init__.py
@@ -81,10 +81,12 @@ def sync(Lochness, subject, dry=False):
         for daris_uid in daris_uids:
             dirname = tree.get('mri',
                                subject.protected_folder,
-                               processed=False)
+                               processed=False,
+                               BIDS=Lochness['BIDS'])
             metadata_dst_dir = tree.get('mri',
                                         subject.protected_folder,
-                                        processed=True)
+                                        processed=True,
+                                        BIDS=Lochness['BIDS'])
             metadata_dst = Path(metadata_dst_dir) / f'{daris_uid}_metadata.csv'
 
             dst_zipfile = os.path.join(dirname, 'tmp.zip')

--- a/lochness/hdd/buckner.py
+++ b/lochness/hdd/buckner.py
@@ -37,7 +37,7 @@ def sync(Lochness, subject, dry=False, datatypes=None):
                     logger.warn('subject not in PHOENIX {0}/{1}'.format(study, sid))
                     continue
                 src = os.path.join(study_dir, sid)
-                _dst = tree.get(datatype, subject.general, makedirs=False)
+                _dst = tree.get(datatype, subject.general, makedirs=False, BIDS=Lochness['BIDS'])
                 ssh.makedirs(Lochness, _dst)
                 dst = '{0}@{1}:{2}'.format(Lochness['ssh_user'], Lochness['ssh_host'], _dst)
                 hdd.rsync(src, dst, dry=dry)

--- a/lochness/hdd/coombs.py
+++ b/lochness/hdd/coombs.py
@@ -38,7 +38,7 @@ def sync(Lochness, subject, dry=False, datatypes=None):
                     logger.warn('subject not in PHOENIX {0}/{1}'.format(study, sid))
                     continue
                 src = os.path.join(study_dir, sid)
-                _dst = tree.get(datatype, general_folder, subject, makedirs=False)
+                _dst = tree.get(datatype, general_folder, subject, makedirs=False, BIDS=Lochness['BIDS'])
                 ssh.makedirs(Lochness, _dst)
                 dst = '{0}@{1}:{2}'.format(Lochness['ssh_user'], Lochness['ssh_host'], _dst)
                 hdd.rsync(src, dst, dry=dry)

--- a/lochness/icognition/__init__.py
+++ b/lochness/icognition/__init__.py
@@ -52,7 +52,7 @@ def sync(Lochness, subject, dry=False):
                     if content_len != expected_len:
                         raise iCognitionError('content length {0} does not match expected length {1}'.format(content_len, expected_len))
                 # save the file atomically
-                dst = tree.get('cogassess', subject.general_folder)
+                dst = tree.get('cogassess', subject.general_folder, BIDS=Lochness['BIDS'])
                 dst = os.path.join(dst, fname)
                 if os.path.exists(dst):
                     return

--- a/lochness/keyring/__init__.py
+++ b/lochness/keyring/__init__.py
@@ -103,7 +103,7 @@ def mediaflux_api_token(Lochness, key):
     if 'TOKEN' in Lochness['keyring'][key]:
         credentials = ['HOST', 'PORT', 'TRANSPORT', 'TOKEN']
     else:
-        credentials = ['HOST', 'PORT', 'TRANSPORT', 'TOKEN', 'DOMAIN', 'USER', 'PASSWORD']
+        credentials = ['HOST', 'PORT', 'TRANSPORT', 'DOMAIN', 'USER', 'PASSWORD']
 
     auths= Lochness['keyring'][key]
     mflux_cfg= os.path.join(Lochness['phoenix_root'], 'mflux.cfg')

--- a/lochness/mediaflux/__init__.py
+++ b/lochness/mediaflux/__init__.py
@@ -127,17 +127,17 @@ def sync_module(Lochness: 'lochness.config',
                                 remote= remote.split(':')[1]
 
                             # construct local path
-                            protect = prod.get('protect', False)
+                            protect = prod.get('protect', True)
                             processed =  prod.get('processed', False)
                             key = enc_key if protect else None
                             subj_dir = subject.protected_folder \
                                 if protect else subject.general_folder
 
                             # mf_local= pjoin(subj_dir, datatype, dirname(patt), basename(remote))
-                            mf_local = tree.get(datatype,
+                            mf_local = str(tree.get(datatype,
                                                 subj_dir,
                                                 processed=processed,
-                                                BIDS=Lochness['BIDS'])
+                                                BIDS=Lochness['BIDS']))
 
                             # ENH set different permissions
                             # GENERAL: 0o755, PROTECTED: 0700

--- a/lochness/mindlamp/__init__.py
+++ b/lochness/mindlamp/__init__.py
@@ -50,7 +50,10 @@ def sync(Lochness: 'lochness.config',
 
     # set destination folder
     # dst_folder = tree.get('mindlamp', subject.general_folder)
-    dst_folder = tree.get('mindlamp', subject.protected_folder, processed=False)
+    dst_folder = tree.get('mindlamp',
+                          subject.protected_folder,
+                          processed=False,
+                          BIDS=Lochness['BIDS'])
 
     # store both data types
     for data_name, data_dict in zip(['activity', 'sensor'],

--- a/lochness/onlinescoring/__init__.py
+++ b/lochness/onlinescoring/__init__.py
@@ -55,7 +55,7 @@ def sync(Lochness, subject, dry=False):
                 if content_len != expected_len:
                     raise OnlineScoringError('content length {0} does not match expected length {1}'.format(content_len, expected_len))
             # save the file atomically
-            dst = tree.get('retroquest', subject.general_folder)
+            dst = tree.get('retroquest', subject.general_folder, BIDS=Lochness['BIDS'])
             dst = os.path.join(dst, fname)
             if os.path.exists(dst):
                 return

--- a/lochness/redcap/__init__.py
+++ b/lochness/redcap/__init__.py
@@ -215,14 +215,17 @@ def sync(Lochness, subject, dry=False):
             # default location to protected folder
             dst_folder = tree.get('surveys',
                                   subject.protected_folder,
-                                  processed=False)
+                                  processed=False,
+                                  BIDS=Lochness['BIDS'])
             fname = f'{redcap_subject}.{_redcap_project}.json'
             dst = Path(dst_folder) / fname
 
             # PII processed content to general processed
             proc_folder = tree.get('surveys',
                                    subject.general_folder,
-                                   processed=True)
+                                   processed=True,
+                                   BIDS=Lochness['BIDS'])
+
             proc_dst = Path(proc_folder) / fname
 
             # check if the data has been updated by checking the redcap data

--- a/lochness/rpms/__init__.py
+++ b/lochness/rpms/__init__.py
@@ -143,12 +143,14 @@ def sync(Lochness, subject, dry=False):
         # target data
         dirname = tree.get('surveys',
                            subject.protected_folder,
-                           processed=False)
+                           processed=False,
+                           BIDS=Lochness['BIDS'])
         target_df_loc = Path(dirname) / f"{subject_id}_{measure}.csv"
 
         proc_folder = tree.get('surveys',
                                subject.general_folder,
-                               processed=True)
+                               processed=True,
+                               BIDS=Lochness['BIDS'])
         proc_dst = Path(proc_folder) / f"{subject_id}_{measure}.csv"
 
         # load the time of the lastest data pull from daris

--- a/lochness/tree/__init__.py
+++ b/lochness/tree/__init__.py
@@ -1,5 +1,7 @@
 import os
+import sys
 import logging
+from pathlib import Path
 from string import Template
 
 Templates = {
@@ -74,18 +76,37 @@ def get(data_type, base, **kwargs):
     raw_folder = None
     processed_folder = None
 
-    if 'raw' in Templates[data_type]:
-        raw_folder = Templates[data_type]['raw'].substitute(base=base, **kwargs)
+    if kwargs.get('BIDS', True):   # PHOENIX to BIDS
+        phoenix_id = Path(base).parent.name   # get SUBJECT
+        if 'raw' in Templates[data_type]:
+            # restructure root
+            base = Path(base).parent.parent / 'raw' / phoenix_id
+            raw_folder = Templates[data_type]['raw'].substitute(
+                    base=str(base), **kwargs)
+            raw_folder = Path(raw_folder).parent  # remove the 'raw' at the end
 
-    if 'processed' in Templates[data_type]:
-        processed_folder = Templates[data_type]['processed'].substitute(base=base, **kwargs)
+        if 'processed' in Templates[data_type]:
+            # restructure root
+            base = Path(base).parent.parent / 'processed' / phoenix_id
+            processed_folder = Templates[data_type]['processed'].substitute(
+                    base=base, **kwargs)
+            # remove the 'processed' at the end
+            processed_folder = Path(processed_folder).parent
+    else:
+        if 'raw' in Templates[data_type]:
+            raw_folder = Templates[data_type]['raw'].substitute(
+                    base=base, **kwargs)
+
+        if 'processed' in Templates[data_type]:
+            processed_folder = Templates[data_type]['processed'].substitute(
+                    base=base, **kwargs)
 
     if kwargs.get('makedirs', True):
         if raw_folder and not os.path.exists(raw_folder):
-            logger.debug('creating raw folder {0}'.format(raw_folder))
+            logger.debug(f'creating raw folder {raw_folder}')
             os.makedirs(raw_folder)
         if processed_folder and not os.path.exists(processed_folder):
-            logger.debug('creating processed folder {0}'.format(processed_folder))
+            logger.debug(f'creating processed folder {processed_folder}')
             os.makedirs(processed_folder)
             os.chmod(processed_folder, 0o01777)
 

--- a/lochness/tree/__init__.py
+++ b/lochness/tree/__init__.py
@@ -9,6 +9,10 @@ Templates = {
         'raw': Template('${base}/actigraphy/raw'),
         'processed': Template('${base}/actigraphy/processed')
     },
+    'eeg': {
+        'raw': Template('${base}/eeg/raw'),
+        'processed': Template('${base}/eeg/processed')
+    },
     'mri': {
         'raw': Template('${base}/mri/raw'),
         'processed': Template('${base}/mri/processed')
@@ -55,6 +59,10 @@ Templates = {
     'onsite_interview': {
         'raw': Template('${base}/onsite_interview/raw'),
         'processed': Template('${base}/onsite_interview/processed')
+    },
+    'interviews': {
+        'raw': Template('${base}/interviews/raw'),
+        'processed': Template('${base}/interviews/processed')
     },
     'surveys': {
         'raw': Template('${base}/surveys/raw'),

--- a/lochness/tree/__init__.py
+++ b/lochness/tree/__init__.py
@@ -29,7 +29,7 @@ Templates = {
         'processed': Template('${base}/mri_eye/processed/eyeTracking')
     },
     'phone': {
-        'raw': Template('${base}/phone/raw/${beiwe_id}'),
+        'raw': Template('${base}/phone/raw'),
         'processed': Template('${base}/phone/processed')
     },
     'physio': {

--- a/lochness/xnat/__init__.py
+++ b/lochness/xnat/__init__.py
@@ -27,7 +27,8 @@ def sync(Lochness, subject, dry=False):
                 logger.info(experiment)
                 dirname = tree.get('mri',
                                    subject.protected_folder,
-                                   processed=False)
+                                   processed=False,
+                                   BIDS=Lochness['BIDS'])
                 dst = os.path.join(dirname, experiment.label)
                 if os.path.exists(dst):
                     try:

--- a/scripts/lochness_create_template.py
+++ b/scripts/lochness_create_template.py
@@ -233,26 +233,31 @@ redcap:
         for study in args.studies:
             line_to_add = f'''
     {study}:
-        namespace: /DATA/ROOT/UNDER/BOX
+        namespace: /DATA/ROOT/UNDER/MEDIAFLUX
         delete_on_success: False
         file_patterns:
             actigraphy:
                 - vendor: Philips
                   product: Actiwatch 2
-                  data_dir: all_BWH_actigraphy
-                  pattern: 'accel/*csv'
+                  data_dir: actigraphy
+                  pattern: '*csv'
                   protect: True
                 - vendor: Activinsights
                   product: GENEActiv
-                  data_dir: all_BWH_actigraphy
-                  pattern: 'GENEActiv/*bin,GENEActiv/*csv'
+                  data_dir: actigraphy
+                  pattern: '*csv'
                 - vendor: Insights
                   product: GENEActivQC
-                  data_dir: all_BWH_actigraphy
-                  pattern: 'GENEActivQC/*csv'
-            phone:
-                - data_dir: all_phone
-                  pattern: 'processed/accel/*csv'
+                  data_dir: actigraphy
+                  pattern: '*csv'
+            eeg:
+                   - product: eeg
+                     data_dir: eeg
+                     pattern: '*.csv'
+            interviews:
+                   - product: offsite_interview
+                     data_dir: interviews
+                     pattern: '*.mp4'
               '''
 
             config_example += line_to_add
@@ -263,23 +268,31 @@ redcap:
         for study in args.studies:
             line_to_add = f'''
     {study}:
-        base: codmtg
+        base: /DATA/ROOT/UNDER/BOX
         delete_on_success: False
         file_patterns:
             actigraphy:
-                   - vendor: Philips
-                     product: Actiwatch 2
+                - vendor: Philips
+                  product: Actiwatch 2
+                  data_dir: actigraphy
+                  pattern: '*csv'
+                  protect: True
+                - vendor: Activinsights
+                  product: GENEActiv
+                  data_dir: actigraphy
+                  pattern: '*csv'
+                - vendor: Insights
+                  product: GENEActivQC
+                  data_dir: actigraphy
+                  pattern: '*csv'
+            eeg:
+                   - product: eeg
+                     data_dir: eeg
                      pattern: '*.csv'
-                     protect: False
-                   - vendor: Activinsights
-                     product: GENEActiv
-                     pattern: 'GENEActiv/*bin,GENEActive/*csv'
-                     protect: True
-            mri_eye:
-                   - vendor: SR Research
-                     product: EyeLink 1000
-                     pattern: '*.mov'
-                     protect: True
+            interviews:
+                   - product: offsite_interview
+                     data_dir: interviews
+                     pattern: '*.mp4'
              '''
 
             config_example += line_to_add

--- a/scripts/lochness_create_template.py
+++ b/scripts/lochness_create_template.py
@@ -207,6 +207,7 @@ def create_config_template(config_loc: Path, args: object) -> None:
 
     config_example = f'''keyring_file: {args.outdir}/.lochness.enc
 phoenix_root: {args.outdir}/PHOENIX
+BIDS: True
 pid: {args.outdir}/lochness.pid
 stderr: {args.outdir}/lochness.stderr
 stdout: {args.outdir}/lochness.stdout

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -70,7 +70,7 @@ def main():
                              '2017-01-01T15:00:00')
     parser.add_argument('-lss', '--lochness_sync_send',
                         action='store_true',
-                        default=True,
+                        default=False,
                         help='Enable lochness to lochness transfer on the '
                              'sender side')
     parser.add_argument('-lsr', '--lochness_sync_receive',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ requires = [
     'mano',
     'yaxil',
     'six',
-    'pytz'
+    'pytz',
+    'pandas'
 ]
 
 test_requirements = [
@@ -38,6 +39,9 @@ setup(
     scripts=[
         'scripts/sync.py',
         'scripts/phoenix-generator.py'
+        'scripts/listen_to_redcap.py',
+        'scripts/lochness_check_config.py',
+        'scripts/lochness_create_template.py',
     ],
     install_requires=requires,
     tests_require=test_requirements

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ requires = [
     'yaxil',
     'six',
     'pytz',
-    'pandas'
+    'pandas',
+    'jsonpath_ng'
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     },
     scripts=[
         'scripts/sync.py',
-        'scripts/phoenix-generator.py'
+        'scripts/phoenix-generator.py',
         'scripts/listen_to_redcap.py',
         'scripts/lochness_check_config.py',
         'scripts/lochness_create_template.py',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     },
     scripts=[
         'scripts/sync.py',
-        'scripts/phoenix-generator.py',
+        'scripts/phoenix_generator.py',
         'scripts/listen_to_redcap.py',
         'scripts/lochness_check_config.py',
         'scripts/lochness_create_template.py',

--- a/tests/lochness_test/box/test_box.py
+++ b/tests/lochness_test/box/test_box.py
@@ -61,6 +61,8 @@ def args_and_Lochness():
 
 def test_box_sync_module_default(args_and_Lochness):
     args, Lochness = args_and_Lochness
+
+    Lochness['BIDS'] = False
     # change protect to true for all actigraphy
     for study in args.studies:
         new_list = []
@@ -83,6 +85,30 @@ def test_box_sync_module_default(args_and_Lochness):
     show_tree_then_delete('tmp_lochness')
 
 
+def test_box_sync_module_default_BIDS(args_and_Lochness):
+    args, Lochness = args_and_Lochness
+
+    # change protect to true for all actigraphy
+    for study in args.studies:
+        new_list = []
+        for i in Lochness['box'][study]['file_patterns']['actigraphy']:
+            i['protect'] = False
+            i['processed'] = False
+            new_list.append(i)
+        Lochness['box'][study]['file_patterns']['actigraphy'] = new_list
+
+    for subject in lochness.read_phoenix_metadata(Lochness):
+        sync(Lochness, subject, dry=False)
+
+    for study in args.studies:
+        subject_dir = general_root / study / 'raw' / '1001'
+        print(subject_dir)
+        assert (subject_dir / 'actigraphy').is_dir()
+        assert len(list((subject_dir / 'actigraphy').glob('*csv'))) > 1
+
+    show_tree_then_delete('tmp_lochness')
+
+
 def test_box_sync_module_protected(args_and_Lochness):
     args, Lochness = args_and_Lochness
 
@@ -99,15 +125,13 @@ def test_box_sync_module_protected(args_and_Lochness):
         sync(Lochness, subject, dry=False)
 
     for study in args.studies:
-        subject_dir = protected_root / study / '1001'
+        subject_dir = protected_root / study / 'raw' / '1001'
         assert (subject_dir / 'actigraphy').is_dir()
-        assert (subject_dir / 'actigraphy/raw').is_dir()
-        assert len(list((subject_dir / 'actigraphy/raw/').glob('*csv'))) > 1
+        assert len(list((subject_dir / 'actigraphy').glob('*csv'))) > 1
 
         subject_dir = general_root / study / '1001'
         assert (subject_dir / 'actigraphy').is_dir() == False
-        assert (subject_dir / 'actigraphy/raw').is_dir() == False
-        assert len(list((subject_dir / 'actigraphy/raw/').glob('*csv'))) == 0
+        assert len(list((subject_dir / 'actigraphy').glob('*csv'))) == 0
 
     show_tree_then_delete('tmp_lochness')
 
@@ -128,15 +152,13 @@ def test_box_sync_module_protect_processed(args_and_Lochness):
         sync(Lochness, subject, dry=False)
 
     for study in args.studies:
-        subject_dir = protected_root / study / '1001'
+        subject_dir = protected_root / study / 'processed' / '1001'
         assert (subject_dir / 'actigraphy').is_dir()
-        assert (subject_dir / 'actigraphy/processed').is_dir()
         assert len(list((subject_dir /
-                        'actigraphy/processed/').glob('*csv'))) > 1
+                        'actigraphy').glob('*csv'))) > 1
 
-        subject_dir = general_root / study / '1001'
+        subject_dir = general_root / study / 'processed' / '1001'
         assert not (subject_dir / 'actigraphy').is_dir()
-        assert not (subject_dir / 'actigraphy/processed').is_dir()
         assert len(list((subject_dir /
                          'actigraphy/processed/').glob('*csv'))) == 0
 
@@ -153,9 +175,8 @@ def test_box_sync_module_missing_root(args_and_Lochness):
         sync(Lochness, subject, dry=False)
 
     study = 'StudyA'
-    subject_dir = protected_root / study / '1001'
+    subject_dir = protected_root / study / 'raw' / '1001'
     assert (subject_dir / 'actigraphy').is_dir() == False
-    assert (subject_dir / 'actigraphy/raw').is_dir() == False
 
     show_tree_then_delete('tmp_lochness')
 
@@ -189,8 +210,8 @@ def test_box_sync_module_no_redownload(args_and_Lochness):
     for subject in lochness.read_phoenix_metadata(Lochness):
         sync(Lochness, subject, dry=False)
 
-    a_file_path = general_root / 'StudyA' / '1001' / 'actigraphy' / \
-            'raw' / 'BLS-F6VVM-GENEActivQC-day22to51.csv'
+    a_file_path = general_root / 'StudyA' / 'raw' / '1001' / 'actigraphy' / \
+            'BLS-F6VVM-GENEActivQC-day22to51.csv'
 
     init_time = a_file_path.stat().st_mtime
 
@@ -204,19 +225,17 @@ def test_box_sync_module_no_redownload(args_and_Lochness):
     show_tree_then_delete('tmp_lochness')
 
 
-
-
 def test_box_with_given_structure():
     site_subject = {
             'PronetLA': ['LA123456',
-                            'LA132457',
-                            'LA124358'],
+                         'LA132457',
+                         'LA124358'],
             'PronetSL': ['SL124352',
-                             'SL123453',
-                             'SL124539'],
+                         'SL123453',
+                         'SL124539'],
             'PronetWU': ['WU142358',
-                             'WU124351',
-                             'WU142531']
+                         'WU124351',
+                         'WU142531']
             }
 
     modalities = {
@@ -277,14 +296,14 @@ def test_box_with_given_structure():
 def test_mediaflux_with_given_structure():
     site_subject = {
             'PrescientME': ['ME123456',
-                         'ME132457',
-                         'ME124358'],
+                            'ME132457',
+                            'ME124358'],
             'PrescientAD': ['AD124352',
-                          'AD123453',
-                          'AD124539'],
+                            'AD123453',
+                            'AD124539'],
             'PrescientPE': ['PE142358',
-                          'PE124351',
-                          'PE142531']
+                            'PE124351',
+                            'PE142531']
             }
 
     modalities = {
@@ -337,19 +356,3 @@ def test_mediaflux_with_given_structure():
 
                         with open(final_dir / file_name, 'w') as f:
                             f.write('')
-
-
-
-
-
-
-
-
-
-
-            
-
-
-
-
-

--- a/tests/lochness_test/keyring/test_keyring.py
+++ b/tests/lochness_test/keyring/test_keyring.py
@@ -9,7 +9,9 @@ test_dir = lochness_root / 'tests'
 sys.path.append(str(scripts_dir))
 sys.path.append(str(test_dir))
 
-from test_lochness import Lochness
+from test_lochness import Lochness, show_tree_then_delete
 
 def test_read_phoenix_data(Lochness):
     print_keyring(Lochness)
+    show_tree_then_delete('tmp_lochness')
+

--- a/tests/lochness_test/mediaflux/test_mediaflux.py
+++ b/tests/lochness_test/mediaflux/test_mediaflux.py
@@ -1,0 +1,94 @@
+import lochness
+from lochness.mediaflux import sync
+import lochness.config as config
+
+from pathlib import Path
+import sys
+
+import pytest
+import shutil
+import os
+
+import zipfile
+import tempfile as tf
+import json
+import cryptease as crypt
+import pandas as pd
+
+lochness_root = Path(lochness.__path__[0]).parent
+scripts_dir = lochness_root / 'scripts'
+test_dir = lochness_root / 'tests'
+sys.path.append(str(scripts_dir))
+sys.path.append(str(test_dir))
+from lochness_create_template import create_lochness_template
+
+from test_lochness import Args, Tokens, KeyringAndEncrypt, args, Lochness
+from test_lochness import show_tree_then_delete, config_load_test
+
+
+class Args(Args):
+    def __init__(self, root_dir):
+        super().__init__(root_dir)
+        self.studies = ['StudyA']
+        self.sources = ['Redcap', 'xNat', 'boX', 'mediaflux']
+        self.poll_interval = 10
+
+
+@pytest.fixture
+def args():
+    return Args('test_lochness')
+
+
+class KeyringAndEncryptMediaflux(KeyringAndEncrypt):
+    def __init__(self, tmp_dir):
+        super().__init__(tmp_dir)
+        token = Tokens()
+        HOST, PORT, TRANSPORT, TOKEN, DOMAIN, USER, PASSWORD = \
+                token.read_token_or_get_input('mediaflux')
+
+        self.keyring['mediaflux.StudyA'] = {}
+        self.keyring['mediaflux.StudyA']['HOST'] = HOST
+        self.keyring['mediaflux.StudyA']['PORTJ'] = PORT
+        self.keyring['mediaflux.StudyA']['TRANSPORT'] = TRANSPORT
+        self.keyring['mediaflux.StudyA']['TOKEN'] = TOKEN
+        self.keyring['mediaflux.StudyA']['DOMAIN'] = DOMAIN
+        self.keyring['mediaflux.StudyA']['USER'] = USER
+        self.keyring['mediaflux.StudyA']['PASSWORD'] = PASSWORD
+
+        self.write_keyring_and_encrypt()
+
+
+
+@pytest.fixture
+def Lochness():
+    args = Args('tmp_lochness')
+    create_lochness_template(args)
+    KeyringAndEncryptMediaflux(args.outdir)
+
+    lochness = config_load_test('tmp_lochness/config.yml', '')
+    return lochness
+
+
+def initialize_metadata(Lochness, study_name):
+    df = pd.DataFrame({'Active': [1],
+        'Consent': '1988.-09-16',
+        'Subject ID': 'subject01',
+        'Mediaflux': 'mediaflux.StudyA:5Yp0E'})
+    df_loc = Path(Lochness['phoenix_root']) / 'GENERAL' / \
+            study_name / f"{study_name}_metadata.csv"
+
+    df.to_csv(df_loc, index=False)
+
+
+def test_sync_from_empty(Lochness):
+    dry=False
+    study_name = 'StudyA'
+    initialize_metadata(Lochness, study_name)
+
+    for subject in lochness.read_phoenix_metadata(Lochness,
+                                                  studies=[study_name]):
+        sync(Lochness, subject, dry)
+
+    show_tree_then_delete('tmp_lochness')
+
+

--- a/tests/lochness_test/mediaflux/test_mediaflux.py
+++ b/tests/lochness_test/mediaflux/test_mediaflux.py
@@ -29,7 +29,7 @@ from test_lochness import show_tree_then_delete, config_load_test
 class Args(Args):
     def __init__(self, root_dir):
         super().__init__(root_dir)
-        self.studies = ['StudyA']
+        self.studies = ['PrescientAD']
         self.sources = ['Redcap', 'xNat', 'boX', 'mediaflux']
         self.poll_interval = 10
 
@@ -40,55 +40,63 @@ def args():
 
 
 class KeyringAndEncryptMediaflux(KeyringAndEncrypt):
-    def __init__(self, tmp_dir):
+    def __init__(self, tmp_dir, study):
         super().__init__(tmp_dir)
         token = Tokens()
         HOST, PORT, TRANSPORT, TOKEN, DOMAIN, USER, PASSWORD = \
                 token.read_token_or_get_input('mediaflux')
 
-        self.keyring['mediaflux.StudyA'] = {}
-        self.keyring['mediaflux.StudyA']['HOST'] = HOST
-        self.keyring['mediaflux.StudyA']['PORTJ'] = PORT
-        self.keyring['mediaflux.StudyA']['TRANSPORT'] = TRANSPORT
-        self.keyring['mediaflux.StudyA']['TOKEN'] = TOKEN
-        self.keyring['mediaflux.StudyA']['DOMAIN'] = DOMAIN
-        self.keyring['mediaflux.StudyA']['USER'] = USER
-        self.keyring['mediaflux.StudyA']['PASSWORD'] = PASSWORD
+        self.keyring[f'mediaflux.{study}'] = {}
+        self.keyring[f'mediaflux.{study}']['HOST'] = HOST
+        self.keyring[f'mediaflux.{study}']['PORT'] = PORT
+        self.keyring[f'mediaflux.{study}']['TRANSPORT'] = TRANSPORT
+        # self.keyring['mediaflux.StudyA']['TOKEN'] = TOKEN
+        self.keyring[f'mediaflux.{study}']['DOMAIN'] = DOMAIN
+        self.keyring[f'mediaflux.{study}']['USER'] = USER
+        self.keyring[f'mediaflux.{study}']['PASSWORD'] = PASSWORD
 
         self.write_keyring_and_encrypt()
 
 
-
 @pytest.fixture
-def Lochness():
+def args_and_Lochness():
     args = Args('tmp_lochness')
     create_lochness_template(args)
-    KeyringAndEncryptMediaflux(args.outdir)
+    for study in args.studies:
+        KeyringAndEncryptMediaflux(args.outdir, study)
 
     lochness = config_load_test('tmp_lochness/config.yml', '')
-    return lochness
+
+    return args, lochness
 
 
 def initialize_metadata(Lochness, study_name):
-    df = pd.DataFrame({'Active': [1],
-        'Consent': '1988.-09-16',
-        'Subject ID': 'subject01',
-        'Mediaflux': 'mediaflux.StudyA:5Yp0E'})
+    df = pd.DataFrame({'Active': [1, 1, 1],
+        'Consent': ['1988-09-16', '1988-09-16', '1988-09-16'],
+        'Subject ID': ['subject01', 'subject02', 'subject03'],
+        'Mediaflux': [f'mediaflux.{study_name}:AD123453',
+                      f'mediaflux.{study_name}:AD124352',
+                      f'mediaflux.{study_name}:AD124539']
+        })
+
     df_loc = Path(Lochness['phoenix_root']) / 'GENERAL' / \
             study_name / f"{study_name}_metadata.csv"
 
     df.to_csv(df_loc, index=False)
 
 
-def test_sync_from_empty(Lochness):
+def test_sync_from_empty(args_and_Lochness):
+    args, Lochness = args_and_Lochness
     dry=False
-    study_name = 'StudyA'
-    initialize_metadata(Lochness, study_name)
+    for study_name in args.studies:
+        initialize_metadata(Lochness, study_name)
+        Lochness['mediaflux'][study_name]['namespace'] = \
+            '/projects/proj-5070_prescient-1128.4.380' \
+            '/example_mediaflux_root/' + study_name
 
-    for subject in lochness.read_phoenix_metadata(Lochness,
-                                                  studies=[study_name]):
-        sync(Lochness, subject, dry)
+        for subject in lochness.read_phoenix_metadata(Lochness,
+                                                      studies=[study_name]):
+            sync(Lochness, subject, dry)
 
     show_tree_then_delete('tmp_lochness')
-
 

--- a/tests/lochness_test/mediaflux/test_mediaflux.py
+++ b/tests/lochness_test/mediaflux/test_mediaflux.py
@@ -22,7 +22,7 @@ sys.path.append(str(scripts_dir))
 sys.path.append(str(test_dir))
 from lochness_create_template import create_lochness_template
 
-from test_lochness import Args, Tokens, KeyringAndEncrypt, args, Lochness
+from test_lochness import Args, Tokens, KeyringAndEncrypt, args
 from test_lochness import show_tree_then_delete, config_load_test
 
 

--- a/tests/lochness_test/redcap/test_redcap.py
+++ b/tests/lochness_test/redcap/test_redcap.py
@@ -110,9 +110,8 @@ def lochness_subject_raw_json(LochnessMetadataInitialized):
             continue
 
         phoenix_path = Path(LochnessMetadataInitialized['phoenix_root'])
-        subject_proc_p = phoenix_path / 'PROTECTED' / 'StudyA' / 'subject_1'
-        raw_json = subject_proc_p / 'surveys' / 'raw' / \
-                f"{subject.id}.StudyA.json"
+        subject_proc_p = phoenix_path / 'PROTECTED' / 'StudyA' / 'raw' / 'subject_1'
+        raw_json = subject_proc_p / 'surveys' / f"{subject.id}.StudyA.json"
 
         return LochnessMetadataInitialized, subject, raw_json
 
@@ -207,33 +206,4 @@ def test_sync_det_update_while_diff_file_leads_to_data_overwrite(
         new_content_dict = json.load(json_file)
     assert {'test': 'test'} != new_content_dict
     rmtree('tmp_lochness')
-
-
-def test_save_post_from_redcap():
-    text_body = "redcap_url=https%3A%2F%2Fredcap.partners.org%2Fredcap%2F&project_url=https%3A%2F%2Fredcap.partners.org%2Fredcap%2Fredcap_v10.0.30%2Findex.php%3Fpid%3D26709&project_id=26709&username=kc244&record=1001_1&instrument=inclusionexclusion_checklist&inclusionexclusion_checklist_complete=0"
-    save_post_from_redcap(text_body, 'ha.csv')
-
-    print(pd.read_csv('ha.csv'))
-    os.remove('ha.csv')
-
-
-def test_save_post_from_redcap_no_redcap_post():
-    text_body = "hahahoho"
-    if 'redcap' in text_body:
-        save_post_from_redcap(text_body, 'ha.csv')
-    else:
-        print('no redcap post')
-
-    print(pd.read_csv('ha.csv'))
-    os.remove('ha.csv')
-
-
-def test_back_up_db():
-    back_up_db('ha.csv')
-    text_body = "redcap_url=https%3A%2F%2Fredcap.partners.org%2Fredcap%2F&project_url=https%3A%2F%2Fredcap.partners.org%2Fredcap%2Fredcap_v10.0.30%2Findex.php%3Fpid%3D26709&project_id=26709&username=kc244&record=1001_1&instrument=inclusionexclusion_checklist&inclusionexclusion_checklist_complete=0"
-    save_post_from_redcap(text_body, 'ha.csv')
-
-    back_up_db('ha.csv')
-    print(pd.read_csv('ha.csv'))
-    os.remove('ha.csv')
 

--- a/tests/test_lochness.py
+++ b/tests/test_lochness.py
@@ -135,9 +135,14 @@ def config_load_test(f: 'location', archive_base=None):
 
     if archive_base:
         Lochness['phoenix_root'] = archive_base
+
     if 'phoenix_root' not in Lochness:
         raise config.ConfigError('need either --archive-base or '
                           '\'phoenix_root\' in config file')
+
+    if 'BIDS' not in Lochness:
+        Lochness['BIDS'] = False
+
     Lochness['phoenix_root'] = os.path.expanduser(Lochness['phoenix_root'])
     Lochness['keyring_file'] = os.path.expanduser(Lochness['keyring_file'])
 


### PR DESCRIPTION
Mediaflux test working version.

Updates
- data types without `protected` specified to be protected by default
- keyring.__init__ update so the users without TOKEN can also pull the data
- `lochness_create_template` updated to pull the data structure shared to `Prescient`