### PR TITLE
BOX to take path as their base in the config.yml

### DIFF
--- a/lochness/box/__init__.py
+++ b/lochness/box/__init__.py
@@ -96,7 +96,7 @@ def get_box_object_based_on_name(client: boxsdk.client,
     # Return matched box object
     for file_or_folder in root_dir.get_items():
         if file_or_folder.type == 'folder' and \
-           file_or_folder.name == box_folder_name.name:
+           file_or_folder.name == Path(box_folder_name).name:
             return file_or_folder
 
 

--- a/lochness/box/__init__.py
+++ b/lochness/box/__init__.py
@@ -96,7 +96,7 @@ def get_box_object_based_on_name(client: boxsdk.client,
     # Return matched box object
     for file_or_folder in root_dir.get_items():
         if file_or_folder.type == 'folder' and \
-           file_or_folder.name == Path(box_folder_name).name:
+           file_or_folder.name == box_folder_name.name:
             return file_or_folder
 
 

--- a/lochness/keyring/__init__.py
+++ b/lochness/keyring/__init__.py
@@ -155,7 +155,8 @@ def pretty_print_dict(input_dict: dict):
     with tempfile.NamedTemporaryFile(suffix='.json', delete=True) as tmpfile:
         with open(tmpfile.name, 'w') as f:
             json.dump(input_dict, f,
-                    sort_keys=False, indent='  ', separators=(',', ': '))
+                      sort_keys=False, indent='  ',
+                      separators=(',', ': '))
 
         with open(tmpfile.name, 'r') as f:
             lines = f.readlines()

--- a/tests/lochness_test/box/test_box.py
+++ b/tests/lochness_test/box/test_box.py
@@ -121,6 +121,57 @@ def test_box_sync_module_without_edits(args_and_Lochness_BIDS):
     for study in args.studies:
         subject_dir = protected_root / study / 'raw' / 'actigraphy' / '1001'
         assert subject_dir.is_dir()
+
+    show_tree_then_delete('tmp_lochness')
+
+
+def test_box_sync_module_paths_as_the_root_negative_1(args_and_Lochness_BIDS):
+    args, Lochness = args_and_Lochness_BIDS
+
+    for study in args.studies:
+        # new_list = []
+        Lochness['box'][study]['base'] = '/example_box_root/haha/PronetLA'
+
+    for subject in lochness.read_phoenix_metadata(Lochness):
+        sync(Lochness, subject, dry=False)
+
+    for study in args.studies:
+        subject_dir = protected_root / study / 'raw' / 'actigraphy' / '1001'
+        assert ~subject_dir.is_dir()
+
+    show_tree_then_delete('tmp_lochness')
+
+
+def test_box_sync_module_paths_as_the_root_negative_2(args_and_Lochness_BIDS):
+    args, Lochness = args_and_Lochness_BIDS
+
+    for study in args.studies:
+        # new_list = []
+        Lochness['box'][study]['base'] = '/example_box_root/PronetLA/haha'
+
+    for subject in lochness.read_phoenix_metadata(Lochness):
+        sync(Lochness, subject, dry=False)
+
+    for study in args.studies:
+        subject_dir = protected_root / study / 'raw' / 'actigraphy' / '1001'
+        assert ~subject_dir.is_dir()
+
+    show_tree_then_delete('tmp_lochness')
+
+
+def test_box_sync_module_paths_as_the_root_positive(args_and_Lochness_BIDS):
+    args, Lochness = args_and_Lochness_BIDS
+
+    for study in args.studies:
+        # new_list = []
+        Lochness['box'][study]['base'] = '/example_box_root/PronetLA'
+
+    for subject in lochness.read_phoenix_metadata(Lochness):
+        sync(Lochness, subject, dry=False)
+
+    for study in args.studies:
+        subject_dir = protected_root / study / 'raw' / 'actigraphy' / '1001'
+        assert subject_dir.is_dir()
         assert len(list(subject_dir.glob('*csv'))) == 1
 
     show_tree_then_delete('tmp_lochness')

--- a/tests/test_lochness.py
+++ b/tests/test_lochness.py
@@ -117,8 +117,10 @@ class KeyringAndEncrypt():
 
     def write_keyring_and_encrypt(self):
         with open(self.keyring_loc, 'w') as f:
-            json.dump(self.keyring, f)
-        
+            json.dump(self.keyring, f,
+                      sort_keys=False, indent='  ',
+                      separators=(',', ': '))
+
         keyring_content = open(self.keyring_loc, 'rb')
         key = crypt.kdf('')
         crypt.encrypt(


### PR DESCRIPTION
Previously, box module took a string--`base` from the `config.yml` to search the `data_types`. Now, it has been updated to take path as well as string.

eg) 
Previously, it only allowed
```
base: example_root
```

now it also supports
```
base: example_root/ProNET_LA
```