### PR TITLE
REDCap repo with multisite data to create site specific metadata.csv

### DIFF
--- a/lochness/__init__.py
+++ b/lochness/__init__.py
@@ -83,22 +83,24 @@ class Subject(object):
                 'metadata_csv': self.metadata_csv}
         
 
-def initialize_metadata(Lochness, args) -> None:
+def initialize_metadata(Lochness, args, multiple_site_in_a_repo) -> None:
     '''Create (overwrite) metadata.csv using either REDCap or RPMS database'''
     for study_name in args.studies:
         # if 'redcap' or 'rpms' is in the sources, create (overwrite)
         if 'redcap' in args.input_sources:
-            id_fieldname = 'record_id1'
-            consent_fieldname = 'Consent'
+            id_fieldname = 'chric_subject_id'
+            consent_fieldname = 'chric_consent_date'
             REDCap.initialize_metadata(
-                    Lochness, study_name, id_fieldname, consent_fieldname)
+                    Lochness, study_name, id_fieldname, consent_fieldname,
+                    multiple_site_in_a_repo)
 
         elif 'rpms' in args.input_sources:
             # metadata.csv
             id_fieldname = 'record_id1'
             consent_fieldname = 'Consent'
             RPMS.initialize_metadata(
-                    Lochness, study_name, id_fieldname, consent_fieldname)
+                    Lochness, study_name, id_fieldname, consent_fieldname,
+                    multiple_site_in_a_repo)
 
         else:
             pass

--- a/lochness/redcap/__init__.py
+++ b/lochness/redcap/__init__.py
@@ -112,7 +112,7 @@ def initialize_metadata(Lochness: 'Lochness object',
             site_two_letters_redcap_id = item[redcap_id_colname][:2]
             site_two_letters_study = study_name.split('_')[1]
 
-            if not site_two_letters_redcap_id == site_two_letters_study:
+            if site_two_letters_redcap_id != site_two_letters_study:
                 continue
 
         subject_dict = {'Subject ID': item[redcap_id_colname]}

--- a/lochness/rpms/__init__.py
+++ b/lochness/rpms/__init__.py
@@ -45,7 +45,8 @@ def get_rpms_database(rpms_root_path) -> Dict[str, pd.DataFrame]:
 def initialize_metadata(Lochness: 'Lochness object',
                         study_name: str,
                         rpms_id_colname: str,
-                        rpms_consent_colname: str) -> None:
+                        rpms_consent_colname: str,
+                        multistudy: bool = True) -> None:
     '''Initialize metadata.csv by pulling data from RPMS
 
     Key arguments:
@@ -54,7 +55,7 @@ def initialize_metadata(Lochness: 'Lochness object',
         rpms_id_colname: Name of the ID field name in RPMS, str.
         rpms_consent_colname: Name of the consent date field name in RPMS,
                                 str.
-
+        multistudy: True if the rpms repo contains more than one study's data
     '''
     study_rpms = Lochness['keyring'][f'rpms.{study_name}']
     rpms_root_path = study_rpms['RPMS_PATH']
@@ -70,6 +71,13 @@ def initialize_metadata(Lochness: 'Lochness object',
     df = pd.DataFrame()
     # for each record in pulled information, extract subject ID and source IDs
     for measure, df_measure in all_df_dict.items():
+        if multistudy:
+            site_two_letters_rpms_id = df_measure[rpms_id_colname][:2]
+            site_two_letters_study = study_name.split('_')[1]
+
+            if not site_two_letters_rpms_id == site_two_letters_study:
+                continue
+
         subject_dict = {'Subject ID': df_measure[rpms_id_colname]}
 
         # Consent date

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -131,7 +131,10 @@ def do(args):
 
     # initialize (overwrite) metadata.csv using either REDCap or RPMS database
     if 'redcap' in args.input_sources or 'rpms' in args.input_sources:
-        lochness.initialize_metadata(Lochness, args)
+        # for ProNET and PRESCIENT, single REDCap and RPMS repo has information
+        # from multiple site
+        multiple_site_in_a_repo = True
+        lochness.initialize_metadata(Lochness, args, multiple_site_in_a_repo)
 
     for subject in lochness.read_phoenix_metadata(Lochness, args.studies):
         if not subject.active and args.skip_inactive:

--- a/tests/lochness_test/redcap/test_redcap.py
+++ b/tests/lochness_test/redcap/test_redcap.py
@@ -35,6 +35,38 @@ def args_and_Lochness():
     return args, lochness_obj
 
 
+
+@pytest.fixture
+def args_and_Lochness_ampsz():
+    args = Args('tmp_lochness')
+    args.studies = ['ProNET_BA', 'Pronet_LA']
+    create_lochness_template(args)
+    keyring = KeyringAndEncrypt(args.outdir)
+    for study in args.studies:
+        keyring.update_for_ampsz_redcap(study)
+
+    lochness_obj = config_load_test('tmp_lochness/config.yml', '')
+
+    return args, lochness_obj
+
+
+def test_initialize_metadata_ampsz_then_sync(args_and_Lochness_ampsz):
+    args, Lochness = args_and_Lochness_ampsz
+
+    # before initializing metadata
+    for study in args.studies:
+        phoenix_path = Path(Lochness['phoenix_root'])
+        general_path = phoenix_path / 'GENERAL'
+        initialize_metadata(Lochness, study, 'chric_subject_id',
+                'chric_consent_date')
+
+    for subject in lochness.read_phoenix_metadata(Lochness,
+                                                  studies=args.studies):
+        sync(Lochness, subject, False)
+
+    show_tree_then_delete('tmp_lochness')
+
+
 def test_initialize_metadata_function_adding_new_data_to_csv(
         args_and_Lochness):
     args, Lochness = args_and_Lochness
@@ -46,7 +78,7 @@ def test_initialize_metadata_function_adding_new_data_to_csv(
         metadata = general_path / study / f"{study}_metadata.csv"
         assert len(pd.read_csv(metadata)) == 1
 
-        initialize_metadata(Lochness, study, 'record_id1', 'cons_date')
+        initialize_metadata(Lochness, study, 'record_id1', 'cons_date', False)
 
         assert len(pd.read_csv(metadata)) > 3
 
@@ -61,7 +93,7 @@ def test_initialize_metadata_then_sync(args_and_Lochness):
         phoenix_path = Path(Lochness['phoenix_root'])
         general_path = phoenix_path / 'GENERAL'
         metadata = general_path / study / f"{study}_metadata.csv"
-        initialize_metadata(Lochness, study, 'record_id1', 'cons_date')
+        initialize_metadata(Lochness, study, 'record_id1', 'cons_date', False)
 
     for subject in lochness.read_phoenix_metadata(Lochness,
                                                   studies=['StudyA']):
@@ -80,7 +112,7 @@ def LochnessMetadataInitialized(args_and_Lochness):
         general_path = phoenix_path / 'GENERAL'
         metadata = general_path / study / f"{study}_metadata.csv"
 
-        initialize_metadata(Lochness, study, 'record_id1', 'cons_date')
+        initialize_metadata(Lochness, study, 'record_id1', 'cons_date', False)
 
     return Lochness
 
@@ -96,7 +128,7 @@ def test_initialize_metadata_update_when_initialized_again(
         prev_st_mtime = metadata.stat().st_mtime
 
         initialize_metadata(LochnessMetadataInitialized, study,
-                            'record_id1', 'cons_date')
+                            'record_id1', 'cons_date', False)
         post_st_mtime = metadata.stat().st_mtime
 
         assert prev_st_mtime < post_st_mtime
@@ -189,7 +221,10 @@ def test_sync_det_update_while_file_leads_to_mtime_update(
 def test_sync_det_update_while_diff_file_leads_to_data_overwrite(
         lochness_subject_raw_json):
     Lochness, subject, raw_json = lochness_subject_raw_json
+    print(Lochness)
+
     sync(Lochness, subject, False)
+
     # change the content of the existing json
     with open(raw_json, 'w') as json_file:
         json.dump({'test': 'test'}, json_file)
@@ -197,7 +232,7 @@ def test_sync_det_update_while_diff_file_leads_to_data_overwrite(
     text_body = "redcap_url=https%3A%2F%2Fredcap.partners.org%2Fredcap%2F&project_url=https%3A%2F%2Fredcap.partners.org%2Fredcap%2Fredcap_v10.0.30%2Findex.php%3Fpid%3D26709&project_id=26709&username=kc244&record=subject_1&instrument=inclusionexclusion_checklist&inclusionexclusion_checklist_complete=0"
     save_post_from_redcap(
             text_body,
-            Lochness['redcap']['data_entry_trigger_csv'])
+            Lochness['redcap']['StudyA']['data_entry_trigger_csv'])
 
     # second sync without update in the db
     sync(Lochness, subject, False)

--- a/tests/lochness_test/redcap/test_redcap.py
+++ b/tests/lochness_test/redcap/test_redcap.py
@@ -50,6 +50,37 @@ def args_and_Lochness_ampsz():
     return args, lochness_obj
 
 
+@pytest.fixture
+def args_and_Lochness_fake():
+    args = Args('tmp_lochness')
+    args.studies = ['FAKE_AD', 'FAKE_LA']
+    create_lochness_template(args)
+    keyring = KeyringAndEncrypt(args.outdir)
+    for study in args.studies:
+        keyring.update_for_fake_redcap(study)
+
+    lochness_obj = config_load_test('tmp_lochness/config.yml', '')
+
+    return args, lochness_obj
+
+
+def test_initialize_metadata_fake_then_sync(args_and_Lochness_fake):
+    args, Lochness = args_and_Lochness_fake
+
+    # before initializing metadata
+    for study in args.studies:
+        phoenix_path = Path(Lochness['phoenix_root'])
+        general_path = phoenix_path / 'GENERAL'
+        initialize_metadata(Lochness, study,
+                'chric_subject_id',
+                'chric_consent_date')
+
+    for subject in lochness.read_phoenix_metadata(Lochness,
+                                                  studies=args.studies):
+        sync(Lochness, subject, False)
+
+    # show_tree_then_delete('tmp_lochness')
+
 def test_initialize_metadata_ampsz_then_sync(args_and_Lochness_ampsz):
     args, Lochness = args_and_Lochness_ampsz
 

--- a/tests/lochness_test/rpms/test_rpms.py
+++ b/tests/lochness_test/rpms/test_rpms.py
@@ -67,7 +67,7 @@ def test_initializing_based_on_rpms(Lochness):
         - ...
     '''
     create_fake_rpms_repo()
-    initialize_metadata(Lochness, 'StudyA', 'record_id1', 'Consent')
+    initialize_metadata(Lochness, 'StudyA', 'record_id1', 'Consent', False)
     df = pd.read_csv('tmp_lochness/PHOENIX/GENERAL/StudyA/StudyA_metadata.csv')
     show_tree_then_delete('tmp_lochness')
     print(df)
@@ -78,7 +78,7 @@ def test_create_lochness_template(Lochness):
     create_fake_rpms_repo()
     # create_lochness_template(args)
     study_name = 'StudyA'
-    initialize_metadata(Lochness, study_name, 'record_id1', 'Consent')
+    initialize_metadata(Lochness, study_name, 'record_id1', 'Consent', False)
 
     for subject in lochness.read_phoenix_metadata(Lochness,
                                                   studies=['StudyA']):
@@ -118,7 +118,7 @@ def test_sync_from_empty(args):
     dry=False
     study_name = 'StudyA'
     Lochness = config_load_test(f'{args.outdir}/config.yml', '')
-    initialize_metadata(Lochness, study_name, 'record_id1', 'Consent')
+    initialize_metadata(Lochness, study_name, 'record_id1', 'Consent', False)
 
     for subject in lochness.read_phoenix_metadata(Lochness,
                                                   studies=['StudyA']):

--- a/tests/test_lochness.py
+++ b/tests/test_lochness.py
@@ -124,6 +124,15 @@ class KeyringAndEncrypt():
 
         self.write_keyring_and_encrypt()
 
+    def update_for_fake_redcap(self, study):
+        token = Tokens()
+        api_token, url = token.read_token_or_get_input('redcap_fake')
+
+        self.keyring[f'redcap.{study}']['URL'] = url
+        self.keyring[f'redcap.{study}']['API_TOKEN'] = {study: api_token}
+
+        self.write_keyring_and_encrypt()
+
     def write_keyring_and_encrypt(self):
         with open(self.keyring_loc, 'w') as f:
             json.dump(self.keyring, f)

--- a/tests/test_lochness.py
+++ b/tests/test_lochness.py
@@ -115,6 +115,15 @@ class KeyringAndEncrypt():
 
         self.write_keyring_and_encrypt()
 
+    def update_for_ampsz_redcap(self, study):
+        token = Tokens()
+        api_token, url = token.read_token_or_get_input('redcap_ampsz')
+
+        self.keyring[f'redcap.{study}']['URL'] = url
+        self.keyring[f'redcap.{study}']['API_TOKEN'] = {study: api_token}
+
+        self.write_keyring_and_encrypt()
+
     def write_keyring_and_encrypt(self):
         with open(self.keyring_loc, 'w') as f:
             json.dump(self.keyring, f)


### PR DESCRIPTION
@tashrifbillah 
This PR follows our discussion yesterday and in slack.

Tashrif has raised valid and important point that our U01 redcap repo has subjects from multiple sites (studies).

Here is this PR, `lochness.redcap.initialize_metadata` & `lochness.rpms.initialize_metadata` functions are proposed to take `multsite` input argument, which is set as `True` by default.

Since we do not have the site information in the U01 redcap / rpms repo at this moment, we are utilizing the first two letters from the subject ID to be matched to the last two letters of the `study` name given, to selectively populate the corresponding `metadata.csv` with the subjects from each site.